### PR TITLE
게시판 페이징 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.domain.type.SearchType;
-import com.fastcampus.projectboard.dto.ArticleDto;
+import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.projectboard.service.ArticleService;
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/articles")
@@ -46,9 +47,13 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     public String article(ModelMap map, @PathVariable("articleId") Long articleId) {
-        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+        Map<String, Object> result = articleService.getArticle(articleId);
+
+        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from((ArticleWithCommentsDto) result.get("article"));
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
+        map.addAttribute("prevId", result.get("prevId"));
+        map.addAttribute("nextId", result.get("nextId"));
 
         return "articles/detail";
     }

--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,10 +1,13 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.domain.type.SearchType;
+import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -15,12 +18,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/articles")
 @Controller
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final PaginationService paginationService;
 
     @GetMapping
     public String articles(
@@ -29,7 +35,11 @@ public class ArticleController {
             @PageableDefault(size = 10, sort="createdAt", direction= Sort.Direction.DESC) Pageable pageable,
             ModelMap map) {
 
-        map.addAttribute("articles", articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from));
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumber = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("paginationBarNumbers", barNumber);
 
         return "articles/index";
     }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -7,10 +7,14 @@ import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+import java.util.List;
 
 @RepositoryRestResource
 public interface ArticleRepository extends
@@ -40,4 +44,8 @@ public interface ArticleRepository extends
 
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
 
+    @Query(value = "(SELECT id FROM article WHERE ID < :id ORDER BY id DESC LIMIT 1)" +
+            "UNION ALL" +
+            "(SELECT id FROM article WHERE ID > :id ORDER BY id ASC LIMIT 1)", nativeQuery = true )
+    List<Long> findPrevNextArticleIds(@Param(value="id")Long id);
 }

--- a/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
+++ b/src/main/java/com/fastcampus/projectboard/service/PaginationService.java
@@ -1,0 +1,23 @@
+package com.fastcampus.projectboard.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPages) {
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH / 2), 0);
+        int endNumber = Math.min(startNumber + BAR_LENGTH, totalPages);
+
+        return IntStream.range(startNumber, endNumber).boxed().toList();
+    }
+
+    public int currentLength() {
+        return BAR_LENGTH;
+    }
+}

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -75,7 +75,7 @@
 
         <div class="row g-5">
             <nav aria-label="Page navigation example">
-                <ul class="pagination">
+                <ul class="pagination" id="pagination">
                     <li class="page-item">
                         <a class="page-link" href="#" aria-label="Previous">
                             <span aria-hidden="true">&laquo; prev</span>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -19,4 +19,15 @@
             <attr sel="div/p" th:text="${articleComment.content}" />
         </attr>
     </attr>
+
+    <attr sel="#pagination">
+        <attr sel="li[0]/a"
+              th:href="${prevId != null ? '/articles/' + prevId : ''}"
+              th:class="'page-link' + (${prevId} == null ? ' disabled' : '')"
+        />
+        <attr sel="li[1]/a"
+              th:href="${nextId != null ? '/articles/' + nextId : ''}"
+              th:class="'page-link' + (${nextId} == null ? ' disabled' : '')"
+        />
+    </attr>
 </thlogic>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -84,12 +84,10 @@
             <tfoot></tfoot>
         </table>
 
-        <nav aria-label="Page navigation example">
+        <nav id="pagination" aria-label="Page navigation example">
             <ul class="pagination justify-content-center">
                 <li class="page-item"><a class="page-link" href="#">Previous</a></li>
                 <li class="page-item"><a class="page-link" href="#">1</a></li>
-                <li class="page-item"><a class="page-link" href="#">2</a></li>
-                <li class="page-item"><a class="page-link" href="#">3</a></li>
                 <li class="page-item"><a class="page-link" href="#">Next</a></li>
             </ul>
         </nav>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -14,4 +14,24 @@
             </attr>
         </attr>
     </attr>
+
+    <attr sel="#pagination">
+        <attr sel="li[0]/a"
+              th:text="'previous'"
+              th:href="@{/articles(page=${articles.number - 1})}"
+              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+        />
+        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+            <attr sel="a"
+                  th:text="${pageNumber + 1}"
+                  th:href="@{/articles(page=${pageNumber})}"
+                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+            />
+        </attr>
+        <attr sel="li[2]/a"
+              th:text="'next'"
+              th:href="@{/articles(page=${articles.number + 1})}"
+              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+        />
+    </attr>
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -20,7 +20,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -101,7 +103,7 @@ class ArticleControllerTest {
     void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         // given
         Long articleId = 1L;
-        given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticle(articleId)).willReturn(createGetArticleByIdResult());
 
         // when & then
         mvc.perform(get("/articles/1"))
@@ -109,7 +111,8 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attributeExists("nextId"));
 
         then(articleService).should().getArticle(articleId);
     }
@@ -138,6 +141,15 @@ class ArticleControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/search-hashtag"));
+    }
+
+    private Map<String, Object> createGetArticleByIdResult() {
+        Map<String, Object> resultMap = new HashMap<>();
+        resultMap.put("article", createArticleWithCommentsDto());
+        resultMap.put("prevId", null);
+        resultMap.put("nextId", 2);
+
+        return resultMap;
     }
 
     private ArticleWithCommentsDto createArticleWithCommentsDto() {

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -4,6 +4,7 @@ import com.fastcampus.projectboard.config.SecurityConfig;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
 import com.fastcampus.projectboard.service.ArticleService;
+import com.fastcampus.projectboard.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,15 +13,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -36,6 +39,9 @@ class ArticleControllerTest {
     @MockBean
     private ArticleService articleService;
 
+    @MockBean
+    private PaginationService paginationService;
+
 
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -46,16 +52,49 @@ class ArticleControllerTest {
     void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         // given
         given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
 
         // when & then
         mvc.perform(get("/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index"))
-                .andExpect(model().attributeExists("articles"));
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
 
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
+
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
+    @Test
+    void givenPagingAndSortingParams_whenSearchingArticlesPage_thenReturnsArticlesPage() throws Exception {
+        // Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(articleService.searchArticles(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages())).willReturn(barNumbers);
+
+        // When & Then
+        mvc.perform(
+                        get("/articles")
+                                .queryParam("page", String.valueOf(pageNumber))
+                                .queryParam("size", String.valueOf(pageSize))
+                                .queryParam("sort", sortName + "," + direction)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(articleService).should().searchArticles(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
+    }
+
 
     @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")
     @Test

--- a/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,7 +73,8 @@ class ArticleServiceTest {
         given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
 
         // when
-        ArticleWithCommentsDto dto = sut.getArticle(articleId); // 제목, 본문, ID, 닉네임, 해시태그
+        Map<String, Object> resultMap = sut.getArticle(articleId);
+        ArticleWithCommentsDto dto = (ArticleWithCommentsDto) resultMap.get("article"); // 제목, 본문, ID, 닉네임, 해시태그
 
         // then
         assertThat(dto)

--- a/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
@@ -1,0 +1,68 @@
+package com.fastcampus.projectboard.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
+class PaginationServiceTest {
+
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService sut) {
+        this.sut = sut;
+    }
+
+    @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 만들어준다.")
+    @MethodSource
+    @ParameterizedTest(name="[{index}] {0}, {1} => {2}")
+    void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected) {
+        // given
+
+        // when
+        List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber, totalPages);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers() {
+        return Stream.of(
+                arguments(0, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(1, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(2, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(3, 13, List.of(1, 2, 3, 4, 5)),
+                arguments(4, 13, List.of(2, 3, 4, 5, 6)),
+                arguments(5, 13, List.of(3, 4, 5, 6, 7)),
+                arguments(6, 13, List.of(4, 5, 6, 7, 8)),
+                arguments(7, 13, List.of(5, 6, 7, 8, 9)),
+                arguments(8, 13, List.of(6, 7, 8, 9, 10)),
+                arguments(9, 13, List.of(7, 8, 9, 10, 11)),
+                arguments(10, 13, List.of(8, 9, 10, 11, 12)),
+                arguments(11, 13, List.of(9, 10, 11, 12)),
+                arguments(12, 13, List.of(10, 11, 12))
+        );
+    }
+
+    @Test
+    void givenNothing_whenCalling_thenReturnsCurrentBarLength() {
+        // given
+
+        // when
+        int barLength = sut.currentLength();
+
+        // then
+        assertThat(barLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
- PaginationService 생성하여 게시판 페이지 기능 구현
- 게시글 템플릿
@Query를 이용한 native query 사용
강의 내용은 단순하게 articleId -1, +1하고 있기 때문에 만약 중간에 article이 삭제되어 존재하지 않는 걸 감지할 수 없음.
따라서 이를 예방하기 위해 게시글 id 기준으로 앞 /뒤 id를 db에서 조회해도록 구현함